### PR TITLE
Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ sudo: required
 
 env:
   matrix:
-    - LISP=sbcl
+    - LISP=sbcl COVERALLS=true
 
 install:
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
+  - git clone https://github.com/fukamachi/cl-coveralls ~/lisp/cl-coveralls
 
 script:
   - cl -l prove
@@ -15,3 +16,5 @@ script:
        -l cl-who
        -e '(or (prove:run :les-test)
                (uiop:quit -1))'
+       -e '(coveralls:with-coveralls (:exlude (list "t"))
+             (ql:quickload :les))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
 
 script:
   - cl -l prove
-       -e '(ql:quickload :cl-coveralls)'
-       -e '(coveralls:with-coveralls (:exclude (list "t"))
+       -e '(ql:quickload :cl-coveralls)
+           (coveralls:with-coveralls (:exclude (list "t"))
              (prove:run :les-test))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,5 @@ script:
        -l cl-coveralls
        -l trivial-features
        -l babel
-       -e '(or (prove:run :les-test)
-               (uiop:quit -1))'
        -e '(coveralls:with-coveralls (:exclude (list "t"))
-             (ql:quickload :les))'
+             (prove:run :les-test))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ install:
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
   - git clone https://github.com/fukamachi/cl-coveralls ~/lisp/cl-coveralls
   - git clone https://github.com/trivial-features/trivial-features ~/lisp/trivial-features
+  - git clone https://github.com/cl-babel/babel ~/lisp/babel
 
 script:
   - cl -l prove
        -l cl-coveralls
        -l trivial-features
+       -l babel
        -e '(or (prove:run :les-test)
                (uiop:quit -1))'
        -e '(coveralls:with-coveralls (:exlude (list "t"))

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,9 @@ env:
 
 install:
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
-  - git clone https://github.com/fukamachi/cl-coveralls ~/lisp/cl-coveralls
-  - git clone https://github.com/trivial-features/trivial-features ~/lisp/trivial-features
-  - git clone https://github.com/cl-babel/babel ~/lisp/babel
 
 script:
   - cl -l prove
-       -l cl-coveralls
-       -l trivial-features
-       -l babel
+       -e '(ql:quickload :cl-coveralls)'
        -e '(coveralls:with-coveralls (:exclude (list "t"))
              (prove:run :les-test))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ env:
 install:
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
   - git clone https://github.com/fukamachi/cl-coveralls ~/lisp/cl-coveralls
+  - git clone https://github.com/trivial-features/trivial-features ~/lisp/trivial-features
 
 script:
   - cl -l prove
        -l cl-coveralls
+       -l trivial-features
        -e '(or (prove:run :les-test)
                (uiop:quit -1))'
        -e '(coveralls:with-coveralls (:exlude (list "t"))

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ install:
 
 script:
   - cl -l prove
-       -l hunchentoot
-       -l cl-who
+       -l cl-coveralls
        -e '(or (prove:run :les-test)
                (uiop:quit -1))'
        -e '(coveralls:with-coveralls (:exlude (list "t"))

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
        -l babel
        -e '(or (prove:run :les-test)
                (uiop:quit -1))'
-       -e '(coveralls:with-coveralls (:exlude (list "t"))
+       -e '(coveralls:with-coveralls (:exclude (list "t"))
              (ql:quickload :les))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,14 @@ env:
 
 install:
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
+  - git clone https://github.com/fukamachi/cl-coveralls ~/lisp/cl-coveralls
+  - git clone https://github.com/trivial-features/trivial-features ~/lisp/trivial-features
+  - git clone https://github.com/cl-babel/babel ~/lisp/babel
 
 script:
   - cl -l prove
-       -e '(ql:quickload :cl-coveralls)
-           (coveralls:with-coveralls (:exclude (list "t"))
+       -l cl-coveralls
+       -l trivial-features
+       -l babel
+       -e '(coveralls:with-coveralls (:exclude (list "t"))
              (prove:run :les-test))'


### PR DESCRIPTION
### Requirements
N/A

### Description
Add code coverage reporting through Coveralls to the project.

### Benefits
Code coverage reports are now available for tracking through the Coveralls application.

### Possible drawbacks
Currently, we're manually fetching and loading libraries required by cffi. This is necessary because otherwise, quicklisp chokes when trying to load those dependencies.

### Verification process
Refer to CI server builds and Coveralls reports.

### Applicable issues
See issue: #7
